### PR TITLE
Parse bare attributes instead of requiring parameters to be quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.8.0
+
+- **BREAKING CHANGE**: Switch `default` and `from` attributes to take bare parameters. E.g.
+	- Old style: `struct MyStruct(#[config(default = "\"Hello World\"") String)`
+	- New style: `struct MyStruct(#[config(default = "Hello World") String)`
+	- Old style: `struct MyStruct(#[config(default = "5usize") usize)`
+	- New style: `struct MyStruct(#[config(default = 5usize) usize)`
+
 ## 0.7.0
 
 - Initial release.

--- a/confik-macros/Cargo.toml
+++ b/confik-macros/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.66"
 proc-macro = true
 
 [dependencies]
-darling = "0.20.1"
+darling = "0.20.2" # Parse bare items in attributes
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["extra-traits"] }

--- a/confik-macros/Cargo.toml
+++ b/confik-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confik-macros"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Rob Ede <robjtede@icloud.com>"]
 description = "Macros for confik"
 keywords = ["parser", "serde", "utility", "config"]
@@ -21,7 +21,7 @@ syn = { version = "2", features = ["extra-traits"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-confik = "0.7"
+confik = "0.8"
 rustversion = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.7"

--- a/confik-macros/src/lib.rs
+++ b/confik-macros/src/lib.rs
@@ -8,8 +8,8 @@ use darling::{
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote, quote_spanned};
 use syn::{
-    parse, parse_macro_input, spanned::Spanned, DeriveInput, Expr, Generics, Index, Lit, Meta,
-    Path, Type, Visibility,
+    parse2, parse_macro_input, spanned::Spanned, DeriveInput, Expr, Generics, Index, Meta, Path,
+    Type, Visibility,
 };
 
 #[cfg(test)]
@@ -33,17 +33,16 @@ struct FieldFrom {
 }
 
 impl FromMeta for FieldFrom {
-    fn from_value(ty: &Lit) -> darling::Result<Self> {
-        let Lit::Str(ty) = ty else {
-            return Err(darling::Error::unexpected_lit_type(ty).with_span(&ty.span()));
-        };
-
-        let Ok(ty) = ty.parse::<Type>() else {
+    fn from_expr(ty: &Expr) -> darling::Result<Self> {
+        let Ok(ty) = parse2(ty.to_token_stream()) else {
             return Err(syn::Error::new(
                 ty.span(),
-                format!("Unable to parse provided from as rust type: {}", ty.value()),
-            ))
-            .map_err(Into::into);
+                format!(
+                    "Unable to parse provided from ({}) as rust type",
+                    ty.to_token_stream()
+                ),
+            )
+            .into());
         };
 
         Ok(Self { ty })
@@ -94,44 +93,10 @@ impl FromMeta for FieldDefaulter {
 
     fn from_expr(default: &Expr) -> darling::Result<Self> {
         let default = quote_spanned!(default.span() => { #default }.into() );
-        let expr = parse(default.into()).expect("Failed to parse default when wrapped in into");
+        let expr = parse2(default).expect("Failed to parse default when wrapped in into");
         Ok(Self { expr })
     }
 }
-
-/*
-/// Parser for a default attribute
-#[derive(Debug)]
-struct FieldDefaulter {
-    expr: Expr,
-}
-
-impl FromMeta for FieldDefaulter {
-    fn from_word() -> darling::Result<Self> {
-        Ok(Self {
-            expr: syn::parse_str("Default::default()").unwrap(),
-        })
-    }
-
-    fn from_meta(default: &Meta) -> darling::Result<Self> {
-        match preserve_str_literal(default) {
-            Ok(default) => {
-                let default = quote_spanned!(default.span() => { #default }.into() );
-                let expr =
-                    parse(default.into()).expect("Failed to parse default when wrapped in into");
-                Ok(Self { expr })
-            }
-            Err(err) => Err(syn::Error::new(
-                default.span(),
-                format!(
-                    "Unable to parse provided default ({}) as rust expression: {err}",
-                    quote!(default).to_string()
-                ),
-            )
-            .into()),
-        }
-    }
-}*/
 
 /// Implemented for enum variants
 #[derive(Debug, FromVariant)]

--- a/confik-macros/tests/trybuild.rs
+++ b/confik-macros/tests/trybuild.rs
@@ -34,4 +34,5 @@ fn compile_macros() {
     t.compile_fail("tests/trybuild/fail-derive-literal.rs");
     t.compile_fail("tests/trybuild/fail-field-from-unknown-type.rs");
     t.compile_fail("tests/trybuild/fail-uncreatable-type.rs");
+    t.compile_fail("tests/trybuild/fail-not-a-type.rs");
 }

--- a/confik-macros/tests/trybuild.rs
+++ b/confik-macros/tests/trybuild.rs
@@ -27,9 +27,8 @@ fn compile_macros() {
     t.pass("tests/trybuild/21-field-from.rs");
     t.pass("tests/trybuild/22-dataless-types.rs");
 
-    t.compile_fail("tests/trybuild/fail-default-empty.rs");
     t.compile_fail("tests/trybuild/fail-default-parse.rs");
-    t.compile_fail("tests/trybuild/fail-default-numeric-lit.rs");
+    t.compile_fail("tests/trybuild/fail-default-invalid-expr.rs");
     t.compile_fail("tests/trybuild/fail-config-name-value.rs");
     t.compile_fail("tests/trybuild/fail-secret-extra-attr.rs");
     t.compile_fail("tests/trybuild/fail-derive-literal.rs");

--- a/confik-macros/tests/trybuild/14-simple-default.rs
+++ b/confik-macros/tests/trybuild/14-simple-default.rs
@@ -4,7 +4,7 @@ use confik::{ConfigBuilder, TomlSource};
 
 #[derive(confik::Configuration, Debug, PartialEq)]
 struct Config {
-    #[confik(default = "\"hello world\"")]
+    #[confik(default = "hello world")]
     param: String,
 }
 

--- a/confik-macros/tests/trybuild/16-partial-default.rs
+++ b/confik-macros/tests/trybuild/16-partial-default.rs
@@ -14,7 +14,7 @@ const DEFAULT_NUM: usize = 3;
 
 #[derive(Debug, Default, Deserialize, Configuration, PartialEq, Eq, Serialize)]
 struct Present {
-    #[confik(default = "def(DEFAULT_NUM)")]
+    #[confik(default = def(DEFAULT_NUM))]
     partial: PartiallyPresent,
 }
 

--- a/confik-macros/tests/trybuild/18-secret-default.rs
+++ b/confik-macros/tests/trybuild/18-secret-default.rs
@@ -4,7 +4,7 @@ use confik::Configuration;
 
 #[derive(Debug, PartialEq, Eq, Configuration)]
 struct Config {
-    #[confik(secret, default = "\"foo\"")]
+    #[confik(secret, default = "foo")]
     param: String,
 }
 

--- a/confik-macros/tests/trybuild/21-field-from.rs
+++ b/confik-macros/tests/trybuild/21-field-from.rs
@@ -3,7 +3,7 @@ use confik::{Configuration, TomlSource};
 
 #[derive(Debug, Configuration, PartialEq, Eq)]
 struct Config {
-    #[confik(from = "A")]
+    #[confik(from = A)]
     param: String,
 }
 

--- a/confik-macros/tests/trybuild/fail-default-empty.rs
+++ b/confik-macros/tests/trybuild/fail-default-empty.rs
@@ -1,7 +1,0 @@
-#[derive(confik::Configuration)]
-struct Config {
-    #[confik(default = "")]
-    _param: String,
-}
-
-fn main() {}

--- a/confik-macros/tests/trybuild/fail-default-empty.stderr
+++ b/confik-macros/tests/trybuild/fail-default-empty.stderr
@@ -1,5 +1,0 @@
-error: Unable to parse provided default as rust expression:
- --> tests/trybuild/fail-default-empty.rs:3:24
-  |
-3 |     #[confik(default = "")]
-  |                        ^^

--- a/confik-macros/tests/trybuild/fail-default-invalid-expr.rs
+++ b/confik-macros/tests/trybuild/fail-default-invalid-expr.rs
@@ -1,6 +1,6 @@
 #[derive(confik::Configuration)]
 struct Config {
-    #[confik(default = 123)]
+    #[confik(default = Hello World)]
     _param: String,
 }
 

--- a/confik-macros/tests/trybuild/fail-default-invalid-expr.stderr
+++ b/confik-macros/tests/trybuild/fail-default-invalid-expr.stderr
@@ -1,0 +1,5 @@
+error: expected `,`
+ --> tests/trybuild/fail-default-invalid-expr.rs:3:30
+  |
+3 |     #[confik(default = Hello World)]
+  |                              ^^^^^

--- a/confik-macros/tests/trybuild/fail-default-numeric-lit.stderr
+++ b/confik-macros/tests/trybuild/fail-default-numeric-lit.stderr
@@ -1,5 +1,0 @@
-error: Unexpected literal type `int`
- --> tests/trybuild/fail-default-numeric-lit.rs:3:24
-  |
-3 |     #[confik(default = 123)]
-  |                        ^^^

--- a/confik-macros/tests/trybuild/fail-default-parse.rs
+++ b/confik-macros/tests/trybuild/fail-default-parse.rs
@@ -1,6 +1,6 @@
 #[derive(confik::Configuration)]
 struct Config {
-    #[confik(default = "1 + 2")]
+    #[confik(default = 1 + 2)]
     _param: usize,
 }
 

--- a/confik-macros/tests/trybuild/fail-default-parse.stderr
+++ b/confik-macros/tests/trybuild/fail-default-parse.stderr
@@ -1,8 +1,11 @@
 error[E0277]: the trait bound `usize: From<i32>` is not satisfied
  --> tests/trybuild/fail-default-parse.rs:3:24
   |
-3 |     #[confik(default = "1 + 2")]
-  |                        ^^^^^^^ the trait `From<i32>` is not implemented for `usize`
+3 |     #[confik(default = 1 + 2)]
+  |                        ^----
+  |                        |
+  |                        the trait `From<i32>` is not implemented for `usize`
+  |                        this tail expression is of type `i32`
   |
   = help: the following other types implement trait `From<T>`:
             <usize as From<NonZeroUsize>>

--- a/confik-macros/tests/trybuild/fail-field-from-unknown-type.stderr
+++ b/confik-macros/tests/trybuild/fail-field-from-unknown-type.stderr
@@ -1,8 +1,8 @@
 error[E0412]: cannot find type `A` in this scope
  --> tests/trybuild/fail-field-from-unknown-type.rs:6:21
   |
-6 |     #[confik(from = "A")]
-  |                     ^^^ not found in this scope
+6 |     #[confik(from = A)]
+  |                     ^ not found in this scope
   |
 help: you might be missing a type parameter
   |
@@ -12,5 +12,5 @@ help: you might be missing a type parameter
 error[E0412]: cannot find type `A` in this scope
  --> tests/trybuild/fail-field-from-unknown-type.rs:6:21
   |
-6 |     #[confik(from = "A")]
-  |                     ^^^ not found in this scope
+6 |     #[confik(from = A)]
+  |                     ^ not found in this scope

--- a/confik-macros/tests/trybuild/fail-not-a-type.rs
+++ b/confik-macros/tests/trybuild/fail-not-a-type.rs
@@ -3,8 +3,17 @@ use confik::{Configuration, TomlSource};
 
 #[derive(Debug, Configuration, PartialEq, Eq)]
 struct Config {
-    #[confik(from = A)]
+    #[confik(from = { A })]
     param: String,
+}
+
+#[derive(Debug, Default, serde::Deserialize, confik::Configuration)]
+struct A(usize);
+
+impl From<A> for String {
+    fn from(_: A) -> Self {
+        String::from("Hello world")
+    }
 }
 
 fn main() {

--- a/confik-macros/tests/trybuild/fail-not-a-type.stderr
+++ b/confik-macros/tests/trybuild/fail-not-a-type.stderr
@@ -1,0 +1,18 @@
+error: Unable to parse provided from ({ A }) as rust type
+ --> tests/trybuild/fail-not-a-type.rs:6:21
+  |
+6 |     #[confik(from = { A })]
+  |                     ^^^^^
+
+error[E0599]: no function or associated item named `builder` found for struct `Config` in the current scope
+  --> tests/trybuild/fail-not-a-type.rs:20:26
+   |
+5  | struct Config {
+   | ------------- function or associated item `builder` not found for this struct
+...
+20 |     let config = Config::builder()
+   |                          ^^^^^^^ function or associated item not found in `Config`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `builder`, perhaps you need to implement it:
+           candidate #1: `Configuration`

--- a/confik/Cargo.toml
+++ b/confik/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confik"
-version = "0.7.0"
+version = "0.8.0"
 description = "A library for reading application configuration split across multiple sources"
 authors = ["Rob Ede <robjtede@icloud.com>"]
 keywords = ["parser", "serde", "utility", "config"]
@@ -36,7 +36,7 @@ with-url = ["dep:url"]
 with-uuid = ["dep:uuid"]
 
 [dependencies]
-confik-macros = "=0.7.0"
+confik-macros = "=0.8.0"
 
 cfg-if = "1"
 serde = { version = "1", default-features = false, features = ["std", "derive"] }

--- a/confik/examples/defaulting.rs
+++ b/confik/examples/defaulting.rs
@@ -2,7 +2,7 @@ use confik::Configuration;
 
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Data {
-    #[confik(default = "default_elements()")]
+    #[confik(default = default_elements())]
     elements: Vec<usize>,
 }
 
@@ -14,9 +14,9 @@ const FIELD2_DEFAULT: &str = "Hello World";
 
 #[derive(Configuration, Debug, PartialEq, Eq)]
 struct Config {
-    #[confik(default = "5usize")]
+    #[confik(default = 5usize)]
     field1: usize,
-    #[confik(default = "FIELD2_DEFAULT")]
+    #[confik(default = FIELD2_DEFAULT)]
     field2: String,
     data: Data,
 }

--- a/confik/src/lib.rs
+++ b/confik/src/lib.rs
@@ -132,7 +132,7 @@
 //!
 //!   #[derive(Configuration)]
 //!   struct Config {
-//!       #[confik(default = "Data  { a: 1, b: 2 }")]
+//!       #[confik(default = Data  { a: 1, b: 2 })]
 //!       data: Data
 //!   }
 //!
@@ -166,11 +166,11 @@
 //!
 //!   #[derive(confik::Configuration)]
 //!   struct Config {
-//!       #[confik(default = "DEFAULT_VALUE")]
+//!       #[confik(default = DEFAULT_VALUE)]
 //!       a: u32,
-//!       #[confik(default = "\"hello world\"")]
+//!       #[confik(default = "hello world")]
 //!       b: String,
-//!       #[confik(default = "5f32")]
+//!       #[confik(default = 5f32)]
 //!       c: f32,
 //!   }
 //!   ```
@@ -231,7 +231,7 @@
 //!
 //! #[derive(Configuration)]
 //! struct Config {
-//!     #[confik(default = "DEFAULT_DATA")]
+//!     #[confik(default = DEFAULT_DATA)]
 //!     data: Option<usize>
 //! }
 //!

--- a/confik/src/lib.rs
+++ b/confik/src/lib.rs
@@ -213,7 +213,7 @@
 //!
 //! #[derive(confik::Configuration)]
 //! struct Config {
-//!     #[confik(from = "MyForeignTypeCopy")]
+//!     #[confik(from = MyForeignTypeCopy)]
 //!     foreign_data: ForeignType
 //! }
 //! ```


### PR DESCRIPTION
See `CHANGELOG.md` for examples.